### PR TITLE
cakephp 4.5 compatibility: fixes beforeFind not triggered

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=7.2",
         "cakephp/plugin-installer": "*",
-        "cakephp/cakephp": ">=4.0"
+        "cakephp/cakephp": ">=4.5"
     },
     "require-dev": {
         "phpunit/phpunit": "*"

--- a/src/Model/Table/SoftDeleteTrait.php
+++ b/src/Model/Table/SoftDeleteTrait.php
@@ -4,7 +4,7 @@ namespace SoftDelete\Model\Table;
 use Cake\ORM\RulesChecker;
 use Cake\Datasource\EntityInterface;
 use SoftDelete\Error\MissingColumnException;
-use SoftDelete\ORM\Query;
+use SoftDelete\ORM\Query\SelectQuery;
 
 trait SoftDeleteTrait
 {
@@ -34,9 +34,14 @@ trait SoftDeleteTrait
         return $field;
     }
 
-    public function query(): \Cake\ORM\Query
+    /**
+     * Creates a new SelectQuery instance for a table.
+     *
+     * @return \Cake\ORM\Query\SelectQuery
+     */
+    public function selectQuery(): SelectQuery
     {
-        return new Query($this->getConnection(), $this);
+        return new SelectQuery($this->getConnection(), $this);
     }
 
     /**

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -1,9 +1,10 @@
 <?php
-namespace SoftDelete\ORM;
+namespace SoftDelete\ORM\Query;
 
-use Cake\ORM\Query as CakeQuery;
+use ArrayObject;
+use Cake\ORM\Query\SelectQuery as CakeSelectQuery;
 
-class Query extends CakeQuery
+class SelectQuery extends CakeSelectQuery
 {
     /**
      * Cake\ORM\Query::triggerBeforeFind overwritten to add the condition `deleted IS NULL` to every find request
@@ -13,7 +14,14 @@ class Query extends CakeQuery
     public function triggerBeforeFind(): void
     {
         if (!$this->_beforeFindFired && $this->_type === 'select') {
-            parent::triggerBeforeFind();
+            $this->_beforeFindFired = true;
+
+            $repository = $this->getRepository();
+            $repository->dispatchEvent('Model.beforeFind', [
+                $this,
+                new ArrayObject($this->_options),
+                !$this->isEagerLoaded(),
+            ]);
 
             $aliasedField = $this
                 ->getRepository()


### PR DESCRIPTION
Changes to the CakePHP ORM structure make it necessary to extend SelectQuery instead of Query.

Fixes issue #5 